### PR TITLE
Don't replace string format specifier in a loop.

### DIFF
--- a/repcloud/pg_lib.py
+++ b/repcloud/pg_lib.py
@@ -768,9 +768,9 @@ class pg_engine(object):
 						db_handler["cursor"].execute(sql_drop_trg)
 
 						#remove the log table
-						sql_drop_log_table = sql_drop_log_table % tswap[11]
+						replaced_sql_drop_log_table = sql_drop_log_table % tswap[11]
 						self.logger.log_message("Dropping the log table ", 'info')
-						db_handler["cursor"].execute(sql_drop_log_table)
+						db_handler["cursor"].execute(replaced_sql_drop_log_table)
 
 						#remove the old table
 						self.logger.log_message("Dropping the old table", 'info')


### PR DESCRIPTION
The first time through the loop we replace our string with a format specifier (`sql_drop_log_table` containing `%s`) with a string without the format specifier (because we replace it with the log table name).
The second time through the loop, we try and do the same thing, but error because there is no `%s` within the string.
We hit this bug due to the deadlock causing the loop, you can't repro locally without triggering the deadlock resolution procedure.